### PR TITLE
Rename to postal_code/postal code

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ![Correios Logo](http://prodis.net.br/images/ruby/2015/correios_logo.png)
 
-Find Brazilian addresses by zip code, directly from Correios API. No HTML parsers.
+Find Brazilian addresses by postal code, directly from Correios API. No HTML parsers.
 
 ## Installation
 
@@ -33,7 +33,7 @@ iex> Correios.CEP.find_address("54250610")
    neighborhood: "Cavaleiro",
    state: "PE",
    street: "Rua Fernando Amorim",
-   zipcode: "54250610"
+   postal_code: "54250610"
  }}
 
 iex> Correios.CEP.find_address("00000-000")
@@ -46,7 +46,7 @@ iex> Correios.CEP.find_address!("54250-610")
   neighborhood: "Cavaleiro",
   state: "PE",
   street: "Rua Fernando Amorim",
-  zipcode: "54250610"
+  postal_code: "54250610"
 }
 
 iex> Correios.CEP.find_address!("00000-000")
@@ -69,7 +69,7 @@ iex> Correios.CEP.find_address("54250610", request_timeout: 3000, proxy: {"local
    neighborhood: "Cavaleiro",
    state: "PE",
    street: "Rua Fernando Amorim",
-   zipcode: "54250610"
+   postal_code: "54250610"
  }}
 ```
 

--- a/lib/correios/cep.ex
+++ b/lib/correios/cep.ex
@@ -104,7 +104,7 @@ defmodule Correios.CEP do
       |> client().request(options)
       |> parse()
     else
-      {:error, Error.new("postal_code in invalid format")}
+      {:error, Error.new("postal code in invalid format")}
     end
   end
 

--- a/lib/correios/cep.ex
+++ b/lib/correios/cep.ex
@@ -1,18 +1,18 @@
 defmodule Correios.CEP do
   @moduledoc """
-  Find Brazilian addresses by zip code, directly from Correios API. No HTML parsers.
+  Find Brazilian addresses by postal code, directly from Correios API. No HTML parsers.
   """
 
   alias Correios.CEP.{Address, Client, Error, Parser}
 
   @type t :: {:ok, Address.t()} | {:error, Error.t()}
 
-  @zipcode_regex ~r/^\d{5}-?\d{3}$/
+  @postal_code_regex ~r/^\d{5}-?\d{3}$/
 
   @doc """
-  Finds address by the given `zipcode`.
+  Finds address by the given `postal_code`.
 
-  Zip codes with and without "-" separator are accepted.
+  Postal codes with and without "-" separator are accepted.
 
   ## Options
 
@@ -32,7 +32,7 @@ defmodule Correios.CEP do
          neighborhood: "Cavaleiro",
          state: "PE",
          street: "Rua Fernando Amorim",
-         zipcode: "54250610"
+         postal_code: "54250610"
        }}
 
       iex> #{inspect(__MODULE__)}.find_address("54250-610")
@@ -43,7 +43,7 @@ defmodule Correios.CEP do
          neighborhood: "Cavaleiro",
          state: "PE",
          street: "Rua Fernando Amorim",
-         zipcode: "54250610"
+         postal_code: "54250610"
        }}
 
       iex> #{inspect(__MODULE__)}.find_address("54250-610", connection_timeout: 1000, request_timeout: 1000)
@@ -54,7 +54,7 @@ defmodule Correios.CEP do
          neighborhood: "Cavaleiro",
          state: "PE",
          street: "Rua Fernando Amorim",
-         zipcode: "54250610"
+         postal_code: "54250610"
        }}
 
       iex> #{inspect(__MODULE__)}.find_address("54250-610", proxy: {"localhost", 8888})
@@ -65,7 +65,7 @@ defmodule Correios.CEP do
          neighborhood: "Cavaleiro",
          state: "PE",
          street: "Rua Fernando Amorim",
-         zipcode: "54250610"
+         postal_code: "54250610"
        }}
 
       iex> #{inspect(__MODULE__)}.find_address(
@@ -80,36 +80,36 @@ defmodule Correios.CEP do
          neighborhood: "Cavaleiro",
          state: "PE",
          street: "Rua Fernando Amorim",
-         zipcode: "54250610"
+         postal_code: "54250610"
        }}
 
       iex> #{inspect(__MODULE__)}.find_address("00000-000")
       {:error, %#{inspect(Error)}{reason: "CEP NAO ENCONTRADO"}}
 
       iex> #{inspect(__MODULE__)}.find_address("1234567")
-      {:error, %#{inspect(Error)}{reason: "zipcode in invalid format"}}
+      {:error, %#{inspect(Error)}{reason: "postal_code in invalid format"}}
 
       iex> #{inspect(__MODULE__)}.find_address("")
-      {:error, %#{inspect(Error)}{reason: "zipcode is required"}}
+      {:error, %#{inspect(Error)}{reason: "postal_code is required"}}
 
   """
   @spec find_address(String.t(), keyword()) :: t()
-  def find_address(zipcode, options \\ [])
+  def find_address(postal_code, options \\ [])
 
-  def find_address("", _options), do: {:error, Error.new("zipcode is required")}
+  def find_address("", _options), do: {:error, Error.new("postal_code is required")}
 
-  def find_address(zipcode, options) when is_binary(zipcode) and is_list(options) do
-    if valid_zipcode?(zipcode) do
-      zipcode
+  def find_address(postal_code, options) when is_binary(postal_code) and is_list(options) do
+    if valid_postal_code?(postal_code) do
+      postal_code
       |> client().request(options)
       |> parse()
     else
-      {:error, Error.new("zipcode in invalid format")}
+      {:error, Error.new("postal_code in invalid format")}
     end
   end
 
-  @spec valid_zipcode?(String.t()) :: boolean()
-  defp valid_zipcode?(zipcode), do: zipcode =~ @zipcode_regex
+  @spec valid_postal_code?(String.t()) :: boolean()
+  defp valid_postal_code?(postal_code), do: postal_code =~ @postal_code_regex
 
   @spec client :: module()
   defp client, do: Application.get_env(:correios_cep, :client) || Client
@@ -127,7 +127,7 @@ defmodule Correios.CEP do
   defp parse({:error, error}), do: {:error, Parser.parse_error(error)}
 
   @doc """
-  Finds address by a given zip code.
+  Finds address by a given postal code.
 
   Similar to `find_address/2` except it will unwrap the error tuple and raise in case of errors.
 
@@ -140,7 +140,7 @@ defmodule Correios.CEP do
         neighborhood: "Cavaleiro",
         state: "PE",
         street: "Rua Fernando Amorim",
-        zipcode: "54250610"
+        postal_code: "54250610"
       }
 
       iex> #{inspect(__MODULE__)}.find_address!("00000-000")
@@ -148,8 +148,9 @@ defmodule Correios.CEP do
 
   """
   @spec find_address!(String.t(), keyword()) :: Address.t()
-  def find_address!(zipcode, options \\ []) when is_binary(zipcode) and is_list(options) do
-    zipcode
+  def find_address!(postal_code, options \\ [])
+      when is_binary(postal_code) and is_list(options) do
+    postal_code
     |> find_address(options)
     |> case do
       {:ok, response} -> response

--- a/lib/correios/cep.ex
+++ b/lib/correios/cep.ex
@@ -32,7 +32,8 @@ defmodule Correios.CEP do
          neighborhood: "Cavaleiro",
          state: "PE",
          street: "Rua Fernando Amorim",
-         postal_code: "54250610"
+         postal_code: "54250610",
+         zipcode: "54250610"
        }}
 
       iex> #{inspect(__MODULE__)}.find_address("54250-610")
@@ -43,7 +44,8 @@ defmodule Correios.CEP do
          neighborhood: "Cavaleiro",
          state: "PE",
          street: "Rua Fernando Amorim",
-         postal_code: "54250610"
+         postal_code: "54250610",
+         zipcode: "54250610"
        }}
 
       iex> #{inspect(__MODULE__)}.find_address("54250-610", connection_timeout: 1000, request_timeout: 1000)
@@ -54,7 +56,8 @@ defmodule Correios.CEP do
          neighborhood: "Cavaleiro",
          state: "PE",
          street: "Rua Fernando Amorim",
-         postal_code: "54250610"
+         postal_code: "54250610",
+         zipcode: "54250610"
        }}
 
       iex> #{inspect(__MODULE__)}.find_address("54250-610", proxy: {"localhost", 8888})
@@ -65,7 +68,8 @@ defmodule Correios.CEP do
          neighborhood: "Cavaleiro",
          state: "PE",
          street: "Rua Fernando Amorim",
-         postal_code: "54250610"
+         postal_code: "54250610",
+         zipcode: "54250610"
        }}
 
       iex> #{inspect(__MODULE__)}.find_address(
@@ -80,7 +84,8 @@ defmodule Correios.CEP do
          neighborhood: "Cavaleiro",
          state: "PE",
          street: "Rua Fernando Amorim",
-         postal_code: "54250610"
+         postal_code: "54250610",
+         zipcode: "54250610"
        }}
 
       iex> #{inspect(__MODULE__)}.find_address("00000-000")
@@ -140,7 +145,8 @@ defmodule Correios.CEP do
         neighborhood: "Cavaleiro",
         state: "PE",
         street: "Rua Fernando Amorim",
-        postal_code: "54250610"
+        postal_code: "54250610",
+        zipcode: "54250610"
       }
 
       iex> #{inspect(__MODULE__)}.find_address!("00000-000")

--- a/lib/correios/cep.ex
+++ b/lib/correios/cep.ex
@@ -87,7 +87,7 @@ defmodule Correios.CEP do
       {:error, %#{inspect(Error)}{reason: "CEP NAO ENCONTRADO"}}
 
       iex> #{inspect(__MODULE__)}.find_address("1234567")
-      {:error, %#{inspect(Error)}{reason: "postal_code in invalid format"}}
+      {:error, %#{inspect(Error)}{reason: "postal code in invalid format"}}
 
       iex> #{inspect(__MODULE__)}.find_address("")
       {:error, %#{inspect(Error)}{reason: "postal_code is required"}}

--- a/lib/correios/cep/address.ex
+++ b/lib/correios/cep/address.ex
@@ -3,8 +3,7 @@ defmodule Correios.CEP.Address do
   Address structure.
   """
 
-  @enforce_keys [:street, :complement, :neighborhood, :city, :state, :postal_code]
-
+  @enforce_keys [:street, :complement, :neighborhood, :city, :state, :postal_code, :zipcode]
   defstruct @enforce_keys
 
   @type t() :: %__MODULE__{
@@ -13,7 +12,8 @@ defmodule Correios.CEP.Address do
           neighborhood: String.t(),
           city: String.t(),
           state: String.t(),
-          postal_code: String.t()
+          postal_code: String.t(),
+          zipcode: String.t()
         }
   @typep complement :: charlist() | nil
 
@@ -40,7 +40,8 @@ defmodule Correios.CEP.Address do
         neighborhood: "Neighborhood",
         state: "ST",
         street: "Street",
-        postal_code: "12345678"
+        postal_code: "12345678",
+        zipcode: "12345678"
       }
 
   """
@@ -60,6 +61,7 @@ defmodule Correios.CEP.Address do
       city: to_string(city),
       state: to_string(state),
       postal_code: to_string(postal_code),
+      zipcode: to_string(postal_code),
       complement: build_complement(complement1, complement2)
     }
   end

--- a/lib/correios/cep/address.ex
+++ b/lib/correios/cep/address.ex
@@ -3,7 +3,7 @@ defmodule Correios.CEP.Address do
   Address structure.
   """
 
-  @enforce_keys [:street, :complement, :neighborhood, :city, :state, :zipcode]
+  @enforce_keys [:street, :complement, :neighborhood, :city, :state, :postal_code]
 
   defstruct @enforce_keys
 
@@ -13,7 +13,7 @@ defmodule Correios.CEP.Address do
           neighborhood: String.t(),
           city: String.t(),
           state: String.t(),
-          zipcode: String.t()
+          postal_code: String.t()
         }
   @typep complement :: charlist() | nil
 
@@ -32,7 +32,7 @@ defmodule Correios.CEP.Address do
       ...>   complement2: 'complement two ',
       ...>   city: 'City',
       ...>   state: 'ST',
-      ...>   zipcode: '12345678'
+      ...>   postal_code: '12345678'
       ...> })
       %#{inspect(__MODULE__)}{
         city: "City",
@@ -40,7 +40,7 @@ defmodule Correios.CEP.Address do
         neighborhood: "Neighborhood",
         state: "ST",
         street: "Street",
-        zipcode: "12345678"
+        postal_code: "12345678"
       }
 
   """
@@ -52,14 +52,14 @@ defmodule Correios.CEP.Address do
         neighborhood: neighborhood,
         city: city,
         state: state,
-        zipcode: zipcode
+        postal_code: postal_code
       }) do
     %__MODULE__{
       street: to_string(street),
       neighborhood: to_string(neighborhood),
       city: to_string(city),
       state: to_string(state),
-      zipcode: to_string(zipcode),
+      postal_code: to_string(postal_code),
       complement: build_complement(complement1, complement2)
     }
   end

--- a/lib/correios/cep/client.ex
+++ b/lib/correios/cep/client.ex
@@ -15,7 +15,7 @@ defmodule Correios.CEP.Client do
   ]
 
   @doc """
-  Makes a HTTP request to Correios API using the given `zipcode` and `options`.
+  Makes a HTTP request to Correios API using the given `postal_code` and `options`.
 
   ## Examples
 
@@ -30,9 +30,9 @@ defmodule Correios.CEP.Client do
 
   """
   @spec request(String.t(), keyword()) :: t()
-  def request(zipcode, options) do
+  def request(postal_code, options) do
     url = build_url(options)
-    body = build_body(zipcode)
+    body = build_body(postal_code)
     http_options = build_http_options(options)
 
     url
@@ -44,14 +44,14 @@ defmodule Correios.CEP.Client do
   defp build_url(options), do: Keyword.get(options, :url, @default_url)
 
   @spec build_body(String.t()) :: String.t()
-  defp build_body(zipcode) do
+  defp build_body(postal_code) do
     """
     <?xml version="1.0" encoding="UTF-8"?>
     <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:cli="http://cliente.bean.master.sigep.bsb.correios.com.br/">
       <soapenv:Header />
       <soapenv:Body>
         <cli:consultaCEP>
-          <cep>#{zipcode}</cep>
+          <cep>#{postal_code}</cep>
         </cli:consultaCEP>
       </soapenv:Body>
     </soapenv:Envelope>

--- a/lib/correios/cep/parser.ex
+++ b/lib/correios/cep/parser.ex
@@ -14,7 +14,7 @@ defmodule Correios.CEP.Parser do
     neighborhood: "bairro",
     city: "cidade",
     state: "uf",
-    zipcode: "cep"
+    postal_code: "cep"
   ]
 
   @xmap_params for {new_key, old_key} <- @address_map,

--- a/mix.exs
+++ b/mix.exs
@@ -55,7 +55,7 @@ defmodule Correios.CEP.MixProject do
 
   defp description do
     """
-    Find Brazilian addresses by zip code, directly from Correios API. No HTML parsers.
+    Find Brazilian addresses by postal code, directly from Correios API. No HTML parsers.
     """
   end
 

--- a/test/correios/cep/address_test.exs
+++ b/test/correios/cep/address_test.exs
@@ -27,7 +27,8 @@ defmodule Correios.CEP.AddressTest do
         neighborhood: "Neighborhood",
         city: "City",
         state: "ST",
-        postal_code: "12345678"
+        postal_code: "12345678",
+        zipcode: "12345678"
       }
 
       assert Subject.new(params) == expected_address
@@ -42,7 +43,8 @@ defmodule Correios.CEP.AddressTest do
         neighborhood: "Neighborhood",
         city: "City",
         state: "ST",
-        postal_code: "12345678"
+        postal_code: "12345678",
+        zipcode: "12345678"
       }
 
       assert Subject.new(params) == expected_address

--- a/test/correios/cep/address_test.exs
+++ b/test/correios/cep/address_test.exs
@@ -14,7 +14,7 @@ defmodule Correios.CEP.AddressTest do
         neighborhood: 'Neighborhood',
         city: 'City',
         state: 'ST',
-        zipcode: '12345678'
+        postal_code: '12345678'
       }
 
       {:ok, params: params}
@@ -27,7 +27,7 @@ defmodule Correios.CEP.AddressTest do
         neighborhood: "Neighborhood",
         city: "City",
         state: "ST",
-        zipcode: "12345678"
+        postal_code: "12345678"
       }
 
       assert Subject.new(params) == expected_address
@@ -42,7 +42,7 @@ defmodule Correios.CEP.AddressTest do
         neighborhood: "Neighborhood",
         city: "City",
         state: "ST",
-        zipcode: "12345678"
+        postal_code: "12345678"
       }
 
       assert Subject.new(params) == expected_address

--- a/test/correios/cep/integration_test.exs
+++ b/test/correios/cep/integration_test.exs
@@ -13,7 +13,7 @@ defmodule Correios.CEP.IntegrationTest do
       neighborhood: "Bela Vista",
       city: "São Paulo",
       state: "SP",
-      zipcode: "01311200"
+      postal_code: "01311200"
     }
 
     not_found_error = %Error{

--- a/test/correios/cep/integration_test.exs
+++ b/test/correios/cep/integration_test.exs
@@ -13,7 +13,8 @@ defmodule Correios.CEP.IntegrationTest do
       neighborhood: "Bela Vista",
       city: "São Paulo",
       state: "SP",
-      postal_code: "01311200"
+      postal_code: "01311200",
+      zipcode: "01311200"
     }
 
     not_found_error = %Error{

--- a/test/correios/cep/parser_test.exs
+++ b/test/correios/cep/parser_test.exs
@@ -16,7 +16,8 @@ defmodule Correios.CEP.ParserTest do
         neighborhood: "Cavaleiro",
         city: "Jaboatão dos Guararapes",
         state: "PE",
-        postal_code: "54250610"
+        postal_code: "54250610",
+        zipcode: "54250610"
       }
 
       assert Subject.parse_ok(response) == expected_address

--- a/test/correios/cep/parser_test.exs
+++ b/test/correios/cep/parser_test.exs
@@ -16,7 +16,7 @@ defmodule Correios.CEP.ParserTest do
         neighborhood: "Cavaleiro",
         city: "Jaboatão dos Guararapes",
         state: "PE",
-        zipcode: "54250610"
+        postal_code: "54250610"
       }
 
       assert Subject.parse_ok(response) == expected_address

--- a/test/correios/cep_test.exs
+++ b/test/correios/cep_test.exs
@@ -7,7 +7,7 @@ defmodule Correios.CEPTest do
 
   doctest Subject
 
-  @invalid_zipcodes ~w(
+  @invalid_postal_codes ~w(
     1234567
     123456789
     1234-5678
@@ -24,75 +24,75 @@ defmodule Correios.CEPTest do
       neighborhood: "Cavaleiro",
       city: "Jaboatão dos Guararapes",
       state: "PE",
-      zipcode: "54250610"
+      postal_code: "54250610"
     }
 
     {:ok, address: address}
   end
 
   describe "find_address/1" do
-    test "when zip code is valid and address is found, returns the address", %{
+    test "when postal code is valid and address is found, returns the address", %{
       address: expected_address
     } do
       assert Subject.find_address("54250-610") == {:ok, expected_address}
     end
 
-    test "when zip code is valid (no hyphen) and address is found, returns the address", %{
+    test "when postal code is valid (no hyphen) and address is found, returns the address", %{
       address: expected_address
     } do
       assert Subject.find_address("54250610") == {:ok, expected_address}
     end
 
-    test "when zip code is valid and address is not found, returns not found error" do
+    test "when postal code is valid and address is not found, returns not found error" do
       expected_error = %Error{reason: "CEP NAO ENCONTRADO"}
 
       assert Subject.find_address("00000-000") == {:error, expected_error}
     end
 
-    test "when zip code is empty, returns required error" do
-      expected_error = %Error{reason: "zipcode is required"}
+    test "when postal code is empty, returns required error" do
+      expected_error = %Error{reason: "postal_code is required"}
 
       assert Subject.find_address("") == {:error, expected_error}
     end
 
-    test "when zip code has invalid format, returns invalid format error" do
-      expected_error = %Error{reason: "zipcode in invalid format"}
+    test "when postal code has invalid format, returns invalid format error" do
+      expected_error = %Error{reason: "postal_code in invalid format"}
 
-      Enum.each(@invalid_zipcodes, fn zipcode ->
-        assert Subject.find_address(zipcode) == {:error, expected_error}
+      Enum.each(@invalid_postal_codes, fn postal_code ->
+        assert Subject.find_address(postal_code) == {:error, expected_error}
       end)
     end
   end
 
   describe "find_address!/1" do
-    test "when zip code is valid and address is found, returns the address", %{
+    test "when postal code is valid and address is found, returns the address", %{
       address: expected_address
     } do
       assert Subject.find_address!("54250-610") == expected_address
     end
 
-    test "when zip code is valid (no hyphen) and address is found, returns the address", %{
+    test "when postal code is valid (no hyphen) and address is found, returns the address", %{
       address: expected_address
     } do
       assert Subject.find_address!("54250610") == expected_address
     end
 
-    test "when zip code is valid and address is not found, raises not found error" do
+    test "when postal code is valid and address is not found, raises not found error" do
       assert_raise Error, "CEP NAO ENCONTRADO", fn ->
         Subject.find_address!("00000-000")
       end
     end
 
-    test "when zip code is empty, raises required error" do
-      assert_raise Error, "zipcode is required", fn ->
+    test "when postal code is empty, raises required error" do
+      assert_raise Error, "postal_code is required", fn ->
         Subject.find_address!("")
       end
     end
 
-    test "when zip code has invalid format, raises invalid format error" do
-      Enum.each(@invalid_zipcodes, fn zipcode ->
-        assert_raise Error, "zipcode in invalid format", fn ->
-          Subject.find_address!(zipcode)
+    test "when postal code has invalid format, raises invalid format error" do
+      Enum.each(@invalid_postal_codes, fn postal_code ->
+        assert_raise Error, "postal_code in invalid format", fn ->
+          Subject.find_address!(postal_code)
         end
       end)
     end

--- a/test/correios/cep_test.exs
+++ b/test/correios/cep_test.exs
@@ -56,7 +56,7 @@ defmodule Correios.CEPTest do
     end
 
     test "when postal code has invalid format, returns invalid format error" do
-      expected_error = %Error{reason: "postal_code in invalid format"}
+      expected_error = %Error{reason: "postal code in invalid format"}
 
       Enum.each(@invalid_postal_codes, fn postal_code ->
         assert Subject.find_address(postal_code) == {:error, expected_error}
@@ -91,7 +91,7 @@ defmodule Correios.CEPTest do
 
     test "when postal code has invalid format, raises invalid format error" do
       Enum.each(@invalid_postal_codes, fn postal_code ->
-        assert_raise Error, "postal_code in invalid format", fn ->
+        assert_raise Error, "postal code in invalid format", fn ->
           Subject.find_address!(postal_code)
         end
       end)

--- a/test/correios/cep_test.exs
+++ b/test/correios/cep_test.exs
@@ -24,7 +24,8 @@ defmodule Correios.CEPTest do
       neighborhood: "Cavaleiro",
       city: "Jaboatão dos Guararapes",
       state: "PE",
-      postal_code: "54250610"
+      postal_code: "54250610",
+      zipcode: "54250610"
     }
 
     {:ok, address: address}


### PR DESCRIPTION
Rename to postal_code/postal code

- Rename from zipcode to postal_code in ex/exs files
- Rename from Zip codes/zipcode to postal code in text files

Fix #17 