### PR TITLE
Improve response struct

### DIFF
--- a/lib/correios/cep.ex
+++ b/lib/correios/cep.ex
@@ -84,19 +84,21 @@ defmodule Correios.CEP do
        }}
 
       iex> #{inspect(__MODULE__)}.find_address("00000-000")
-      {:error, %#{inspect(Error)}{reason: "CEP NAO ENCONTRADO"}}
+      {:error, %#{inspect(Error)}{type: :some_type, message: "Some message", reason: "CEP NAO ENCONTRADO"}}
 
       iex> #{inspect(__MODULE__)}.find_address("1234567")
-      {:error, %#{inspect(Error)}{reason: "postal code in invalid format"}}
+      {:error, %#{inspect(Error)}{type: :some_type, message: "Some message", reason: "postal code in invalid format"}}
 
       iex> #{inspect(__MODULE__)}.find_address("")
-      {:error, %#{inspect(Error)}{reason: "postal_code is required"}}
+      {:error, %#{inspect(Error)}{type: :some_type, message: "Some message", reason: "postal_code is required"}}
 
   """
   @spec find_address(String.t(), keyword()) :: t()
   def find_address(postal_code, options \\ [])
 
-  def find_address("", _options), do: {:error, Error.new("postal_code is required")}
+  def find_address("", _options) do
+    {:error, Error.new(:some_type, "Some message", "postal_code is required")}
+  end
 
   def find_address(postal_code, options) when is_binary(postal_code) and is_list(options) do
     if valid_postal_code?(postal_code) do
@@ -104,7 +106,7 @@ defmodule Correios.CEP do
       |> client().request(options)
       |> parse()
     else
-      {:error, Error.new("postal code in invalid format")}
+      {:error, Error.new(:some_type, "Some message", "postal code in invalid format")}
     end
   end
 

--- a/lib/correios/cep.ex
+++ b/lib/correios/cep.ex
@@ -84,20 +84,20 @@ defmodule Correios.CEP do
        }}
 
       iex> #{inspect(__MODULE__)}.find_address("00000-000")
-      {:error, %#{inspect(Error)}{type: :some_type, message: "Some message", reason: "CEP NAO ENCONTRADO"}}
+      {:error, %#{inspect(Error)}{type: :postal_code_not_found, message: "Postal code not found", reason: "CEP NAO ENCONTRADO"}}
 
       iex> #{inspect(__MODULE__)}.find_address("1234567")
-      {:error, %#{inspect(Error)}{type: :some_type, message: "Some message", reason: "postal code in invalid format"}}
+      {:error, %#{inspect(Error)}{type: :postal_code_invalid, message: "Postal code is invalid", reason: "postal code in invalid format"}}
 
       iex> #{inspect(__MODULE__)}.find_address("")
-      {:error, %#{inspect(Error)}{type: :some_type, message: "Some message", reason: "postal_code is required"}}
+      {:error, %#{inspect(Error)}{type: :postal_code_required, message: "Postal code is required", reason: "postal_code is required"}}
 
   """
   @spec find_address(String.t(), keyword()) :: t()
   def find_address(postal_code, options \\ [])
 
   def find_address("", _options) do
-    {:error, Error.new(:some_type, "Some message", "postal_code is required")}
+    {:error, Error.new(:postal_code_required, "Postal code is required", "postal_code is required")}
   end
 
   def find_address(postal_code, options) when is_binary(postal_code) and is_list(options) do
@@ -106,7 +106,7 @@ defmodule Correios.CEP do
       |> client().request(options)
       |> parse()
     else
-      {:error, Error.new(:some_type, "Some message", "postal code in invalid format")}
+      {:error, Error.new(:postal_code_invalid, "Postal code is invalid", "postal code in invalid format")}
     end
   end
 
@@ -156,7 +156,7 @@ defmodule Correios.CEP do
     |> find_address(options)
     |> case do
       {:ok, response} -> response
-      {:error, error} -> raise(error)
+      {:error, error} -> raise(Error, Error.reason(error))
     end
   end
 end

--- a/lib/correios/cep.ex
+++ b/lib/correios/cep.ex
@@ -97,7 +97,8 @@ defmodule Correios.CEP do
   def find_address(postal_code, options \\ [])
 
   def find_address("", _options) do
-    {:error, Error.new(:postal_code_required, "Postal code is required", "postal_code is required")}
+    {:error,
+     Error.new(:postal_code_required, "Postal code is required", "postal_code is required")}
   end
 
   def find_address(postal_code, options) when is_binary(postal_code) and is_list(options) do
@@ -106,7 +107,8 @@ defmodule Correios.CEP do
       |> client().request(options)
       |> parse()
     else
-      {:error, Error.new(:postal_code_invalid, "Postal code is invalid", "postal code in invalid format")}
+      {:error,
+       Error.new(:postal_code_invalid, "Postal code is invalid", "postal code in invalid format")}
     end
   end
 

--- a/lib/correios/cep/error.ex
+++ b/lib/correios/cep/error.ex
@@ -3,9 +3,9 @@ defmodule Correios.CEP.Error do
   Error structure.
   """
 
-  @enforce_keys [:reason]
+  @enforce_keys [:type, :message, :reason]
 
-  @type t() :: %__MODULE__{reason: String.t()}
+  @type t() :: %__MODULE__{type: atom(), message: String.t(), reason: String.t()}
 
   defexception @enforce_keys
 
@@ -14,33 +14,53 @@ defmodule Correios.CEP.Error do
 
   ## Examples
 
-      iex> #{inspect(__MODULE__)}.new("Catastrophic error!")
-      %#{inspect(__MODULE__)}{reason: "Catastrophic error!"}
+      iex> #{inspect(__MODULE__)}.new(:some_type, "Some message", "Catastrophic error!")
+      %#{inspect(__MODULE__)}{type: :some_type, message: "Some message", reason: "Catastrophic error!"}
 
-      iex> #{inspect(__MODULE__)}.new('Catastrophic error!')
-      %#{inspect(__MODULE__)}{reason: "Catastrophic error!"}
+      iex> #{inspect(__MODULE__)}.new(':some_type, 'Some message', "Catastrophic error!")
+      %#{inspect(__MODULE__)}{type: :some_type, message: "Some message", reason: "Catastrophic error!"}
 
-      iex> #{inspect(__MODULE__)}.new(:some_error)
-      %#{inspect(__MODULE__)}{reason: "some_error"}
+      iex> #{inspect(__MODULE__)}.new(:some_type, :some_message, "Catastrophic error!")
+      %#{inspect(__MODULE__)}{type: :some_type, message: "some_message", reason: "Catastrophic error!"}
 
-      iex> #{inspect(__MODULE__)}.new(%{a: 123})
-      %#{inspect(__MODULE__)}{reason: "%{a: 123}"}
+      iex> #{inspect(__MODULE__)}.new(:some_type, %{a: 123}, "Catastrophic error!")
+      %#{inspect(__MODULE__)}{type: :some_type, message: "%{a: 123}", reason: "Catastrophic error!"}
+
+      iex> #{inspect(__MODULE__)}.new(':some_type, "Some message", 'Catastrophic error!')
+      %#{inspect(__MODULE__)}{type: :some_type, message: "Some message", reason: "Catastrophic error!"}
+
+      iex> #{inspect(__MODULE__)}.new(:some_type, "Some message", :some_error)
+      %#{inspect(__MODULE__)}{type: :some_type, message: "Some message", reason: "some_error"}
+
+      iex> #{inspect(__MODULE__)}.new(:some_type, "Some message", %{a: 123})
+      %#{inspect(__MODULE__)}{type: :some_type, message: "Some message", reason: "%{a: 123}"}
 
   """
-  @spec new(any()) :: t()
-  def new(reason), do: %__MODULE__{reason: reason_to_string(reason)}
+  @spec new(any(), any(), any()) :: t()
+  def new(type, message, reason) do
+    %__MODULE__{
+      type: type,
+      message: convert_to_string(message),
+      reason: convert_to_string(reason)
+    }
+  end
 
-  @spec reason_to_string(any()) :: String.t()
-  defp reason_to_string(reason) when is_binary(reason), do: reason
-  defp reason_to_string(reason) when is_atom(reason) or is_list(reason), do: to_string(reason)
-  defp reason_to_string(reason), do: inspect(reason)
+  @spec convert_to_string(any()) :: String.t()
+  defp convert_to_string(message_or_reason) when is_binary(message_or_reason),
+    do: message_or_reason
+
+  defp convert_to_string(message_or_reason)
+       when is_atom(message_or_reason) or is_list(message_or_reason),
+       do: to_string(message_or_reason)
+
+  defp convert_to_string(message_or_reason), do: inspect(message_or_reason)
 
   @doc """
   Returns the reason message of the exception.
 
   ## Examples
 
-      iex> error = %#{inspect(__MODULE__)}{reason: "Catastrophic error!"}
+      iex> error = %#{inspect(__MODULE__)}{type: :some_type, message: "Some message", reason: "Catastrophic error!"}
       ...> #{inspect(__MODULE__)}.message(error)
       "Catastrophic error!"
 

--- a/lib/correios/cep/error.ex
+++ b/lib/correios/cep/error.ex
@@ -17,7 +17,7 @@ defmodule Correios.CEP.Error do
       iex> #{inspect(__MODULE__)}.new(:some_type, "Some message", "Catastrophic error!")
       %#{inspect(__MODULE__)}{type: :some_type, message: "Some message", reason: "Catastrophic error!"}
 
-      iex> #{inspect(__MODULE__)}.new(':some_type, 'Some message', "Catastrophic error!")
+      iex> #{inspect(__MODULE__)}.new(:some_type, 'Some message', "Catastrophic error!")
       %#{inspect(__MODULE__)}{type: :some_type, message: "Some message", reason: "Catastrophic error!"}
 
       iex> #{inspect(__MODULE__)}.new(:some_type, :some_message, "Catastrophic error!")
@@ -26,7 +26,7 @@ defmodule Correios.CEP.Error do
       iex> #{inspect(__MODULE__)}.new(:some_type, %{a: 123}, "Catastrophic error!")
       %#{inspect(__MODULE__)}{type: :some_type, message: "%{a: 123}", reason: "Catastrophic error!"}
 
-      iex> #{inspect(__MODULE__)}.new(':some_type, "Some message", 'Catastrophic error!')
+      iex> #{inspect(__MODULE__)}.new(:some_type, "Some message", 'Catastrophic error!')
       %#{inspect(__MODULE__)}{type: :some_type, message: "Some message", reason: "Catastrophic error!"}
 
       iex> #{inspect(__MODULE__)}.new(:some_type, "Some message", :some_error)

--- a/lib/correios/cep/error.ex
+++ b/lib/correios/cep/error.ex
@@ -62,9 +62,22 @@ defmodule Correios.CEP.Error do
 
       iex> error = %#{inspect(__MODULE__)}{type: :some_type, message: "Some message", reason: "Catastrophic error!"}
       ...> #{inspect(__MODULE__)}.message(error)
+      "Some message"
+
+  """
+  @impl true
+  def message(%__MODULE__{message: message}), do: message
+
+  @doc """
+  Returns the reason message of the exception.
+
+  ## Examples
+
+      iex> error = %#{inspect(__MODULE__)}{type: :some_type, message: "Some message", reason: "Catastrophic error!"}
+      ...> #{inspect(__MODULE__)}.reason(error)
       "Catastrophic error!"
 
   """
   @impl true
-  def message(%__MODULE__{reason: reason}), do: reason
+  def reason(%__MODULE__{reason: reason}), do: reason
 end

--- a/lib/correios/cep/parser.ex
+++ b/lib/correios/cep/parser.ex
@@ -43,7 +43,9 @@ defmodule Correios.CEP.Parser do
   end
 
   @spec build_response(map() | nil) :: Address.t() | Error.t()
-  defp build_response(nil), do: Error.new(:postal_code_not_found, "Postal code not found", "CEP NAO ENCONTRADO")
+  defp build_response(nil),
+    do: Error.new(:postal_code_not_found, "Postal code not found", "CEP NAO ENCONTRADO")
+
   defp build_response(response) when is_map(response), do: Address.new(response)
 
   @doc """

--- a/lib/correios/cep/parser.ex
+++ b/lib/correios/cep/parser.ex
@@ -43,7 +43,7 @@ defmodule Correios.CEP.Parser do
   end
 
   @spec build_response(map() | nil) :: Address.t() | Error.t()
-  defp build_response(nil), do: Error.new(:some_type, "Some message", "CEP NAO ENCONTRADO")
+  defp build_response(nil), do: Error.new(:postal_code_not_found, "Postal code not found", "CEP NAO ENCONTRADO")
   defp build_response(response) when is_map(response), do: Address.new(response)
 
   @doc """
@@ -55,15 +55,15 @@ defmodule Correios.CEP.Parser do
       %#{inspect(Error)}{ ... }
 
       iex> #{inspect(__MODULE__)}.parse_error(:timeout)
-      %#{inspect(Error)}{reason: "timeout"}
+      %#{inspect(Error)}{type: :request_timeout, message: "Request timeout", reason: "timeout"}
 
   """
   @spec parse_error(any()) :: Error.t()
   def parse_error(response) when is_binary(response) do
     reason = xpath(response, ~x"//faultstring/text()")
 
-    Error.new(:some_type, "Some message", reason)
+    Error.new(:postal_code_not_found, "Postal code not found", reason)
   end
 
-  def parse_error(response), do: Error.new(:some_type, "Some message", response)
+  def parse_error(response), do: Error.new(:request_timeout, "Request timeout", response)
 end

--- a/lib/correios/cep/parser.ex
+++ b/lib/correios/cep/parser.ex
@@ -43,7 +43,7 @@ defmodule Correios.CEP.Parser do
   end
 
   @spec build_response(map() | nil) :: Address.t() | Error.t()
-  defp build_response(nil), do: Error.new("CEP NAO ENCONTRADO")
+  defp build_response(nil), do: Error.new(:some_type, "Some message", "CEP NAO ENCONTRADO")
   defp build_response(response) when is_map(response), do: Address.new(response)
 
   @doc """
@@ -60,10 +60,10 @@ defmodule Correios.CEP.Parser do
   """
   @spec parse_error(any()) :: Error.t()
   def parse_error(response) when is_binary(response) do
-    response
-    |> xpath(~x"//faultstring/text()")
-    |> Error.new()
+    reason = xpath(response, ~x"//faultstring/text()")
+
+    Error.new(:some_type, "Some message", reason)
   end
 
-  def parse_error(response), do: Error.new(response)
+  def parse_error(response), do: Error.new(:some_type, "Some message", response)
 end

--- a/test/correios/cep/error_test.exs
+++ b/test/correios/cep/error_test.exs
@@ -6,35 +6,57 @@ defmodule Correios.CEP.ErrorTest do
   doctest Subject
 
   setup do
-    error = %Subject{reason: "Catastrophic error!"}
+    error = %Subject{
+      type: :some_type,
+      message: "Some message",
+      reason: "Catastrophic error!"
+    }
 
     {:ok, error: error}
   end
 
   describe "new/1" do
     test "creates a new error", %{error: expected_error} do
-      assert Subject.new("Catastrophic error!") == expected_error
+      assert Subject.new(:some_type, "Some message", "Catastrophic error!") == expected_error
+    end
+
+    test "when the message is a charlist, converts the message to string", %{
+      error: expected_error
+    } do
+      assert Subject.new(:some_type, 'Some message', 'Catastrophic error!') == expected_error
+    end
+
+    test "when the message is an atom, converts the message to string", %{error: error} do
+      expected_error = %{error | message: "some_message"}
+
+      assert Subject.new(:some_type, :some_message, 'Catastrophic error!') == expected_error
+    end
+
+    test "when the message has another type, converts the message to string", %{error: error} do
+      expected_error = %{error | message: "{:a, 123}"}
+
+      assert Subject.new(:some_type, {:a, 123}, 'Catastrophic error!') == expected_error
     end
 
     test "when the reason is a charlist, converts the reason to string", %{error: expected_error} do
-      assert Subject.new('Catastrophic error!') == expected_error
+      assert Subject.new(:some_type, "Some message", 'Catastrophic error!') == expected_error
     end
 
     test "when the reason is an atom, converts the reason to string", %{error: error} do
       expected_error = %{error | reason: "some_error"}
 
-      assert Subject.new(:some_error) == expected_error
+      assert Subject.new(:some_type, "Some message", :some_error) == expected_error
     end
 
     test "when the reason has another type, converts the reason to string", %{error: error} do
       expected_error = %{error | reason: "{:a, 123}"}
 
-      assert Subject.new({:a, 123}) == expected_error
+      assert Subject.new(:some_type, "Some message", {:a, 123}) == expected_error
     end
   end
 
   describe "message/1" do
-    test "returns the reason message of the error", %{error: error} do
+    test "returns the message of the error", %{error: error} do
       assert Subject.message(error) == "Catastrophic error!"
     end
   end

--- a/test/correios/cep/error_test.exs
+++ b/test/correios/cep/error_test.exs
@@ -57,7 +57,13 @@ defmodule Correios.CEP.ErrorTest do
 
   describe "message/1" do
     test "returns the message of the error", %{error: error} do
-      assert Subject.message(error) == "Catastrophic error!"
+      assert Subject.message(error) == "Some message"
+    end
+  end
+
+  describe "reason/1" do
+    test "returns the reason of the error", %{error: error} do
+      assert Subject.reason(error) == "Catastrophic error!"
     end
   end
 end

--- a/test/correios/cep/integration_test.exs
+++ b/test/correios/cep/integration_test.exs
@@ -17,7 +17,7 @@ defmodule Correios.CEP.IntegrationTest do
     }
 
     not_found_error = %Error{
-      type: :posta_code_not_found,
+      type: :postal_code_not_found,
       message: "Postal code not found",
       reason: "CEP NAO ENCONTRADO"
     }

--- a/test/correios/cep/integration_test.exs
+++ b/test/correios/cep/integration_test.exs
@@ -17,6 +17,8 @@ defmodule Correios.CEP.IntegrationTest do
     }
 
     not_found_error = %Error{
+      type: :posta_code_not_found,
+      message: "Postal code not found",
       reason: "CEP NAO ENCONTRADO"
     }
 

--- a/test/correios/cep/parser_test.exs
+++ b/test/correios/cep/parser_test.exs
@@ -24,6 +24,7 @@ defmodule Correios.CEP.ParserTest do
 
     test "when body is empty, return not found error" do
       response = Fixture.response_body_empty()
+
       expected_error = %Error{
         type: :postal_code_not_found,
         message: "Postal code not found",
@@ -37,6 +38,7 @@ defmodule Correios.CEP.ParserTest do
   describe "parse_error/1" do
     test "returns the parsed error" do
       response = Fixture.response_body_error()
+
       expected_error = %Error{
         type: :postal_code_not_found,
         message: "Postal code not found",
@@ -48,10 +50,10 @@ defmodule Correios.CEP.ParserTest do
 
     test "when error is an atom, returns the parsed error" do
       assert Subject.parse_error(:timeout) == %Error{
-        type: :request_timeout,
-        message: "Request timeout",
-        reason: "timeout"
-      }
+               type: :request_timeout,
+               message: "Request timeout",
+               reason: "timeout"
+             }
     end
   end
 end

--- a/test/correios/cep/parser_test.exs
+++ b/test/correios/cep/parser_test.exs
@@ -24,7 +24,11 @@ defmodule Correios.CEP.ParserTest do
 
     test "when body is empty, return not found error" do
       response = Fixture.response_body_empty()
-      expected_error = %Error{type: :some_type, message: "Some message", reason: "CEP NAO ENCONTRADO"}
+      expected_error = %Error{
+        type: :postal_code_not_found,
+        message: "Postal code not found",
+        reason: "CEP NAO ENCONTRADO"
+      }
 
       assert Subject.parse_ok(response) == expected_error
     end
@@ -33,15 +37,19 @@ defmodule Correios.CEP.ParserTest do
   describe "parse_error/1" do
     test "returns the parsed error" do
       response = Fixture.response_body_error()
-      expected_error = %Error{type: :some_type, message: "Some message", reason: "CEP NAO ENCONTRADO"}
+      expected_error = %Error{
+        type: :postal_code_not_found,
+        message: "Postal code not found",
+        reason: "CEP NAO ENCONTRADO"
+      }
 
       assert Subject.parse_error(response) == expected_error
     end
 
     test "when error is an atom, returns the parsed error" do
       assert Subject.parse_error(:timeout) == %Error{
-        type: :some_type,
-        message: "Some message",
+        type: :request_timeout,
+        message: "Request timeout",
         reason: "timeout"
       }
     end

--- a/test/correios/cep/parser_test.exs
+++ b/test/correios/cep/parser_test.exs
@@ -24,7 +24,7 @@ defmodule Correios.CEP.ParserTest do
 
     test "when body is empty, return not found error" do
       response = Fixture.response_body_empty()
-      expected_error = %Error{reason: "CEP NAO ENCONTRADO"}
+      expected_error = %Error{type: :some_type, message: "Some message", reason: "CEP NAO ENCONTRADO"}
 
       assert Subject.parse_ok(response) == expected_error
     end
@@ -33,13 +33,17 @@ defmodule Correios.CEP.ParserTest do
   describe "parse_error/1" do
     test "returns the parsed error" do
       response = Fixture.response_body_error()
-      expected_error = %Error{reason: "CEP NAO ENCONTRADO"}
+      expected_error = %Error{type: :some_type, message: "Some message", reason: "CEP NAO ENCONTRADO"}
 
       assert Subject.parse_error(response) == expected_error
     end
 
     test "when error is an atom, returns the parsed error" do
-      assert Subject.parse_error(:timeout) == %Error{reason: "timeout"}
+      assert Subject.parse_error(:timeout) == %Error{
+        type: :some_type,
+        message: "Some message",
+        reason: "timeout"
+      }
     end
   end
 end

--- a/test/correios/cep_test.exs
+++ b/test/correios/cep_test.exs
@@ -44,19 +44,31 @@ defmodule Correios.CEPTest do
     end
 
     test "when postal code is valid and address is not found, returns not found error" do
-      expected_error = %Error{type: :some_type, message: "Some message", reason: "CEP NAO ENCONTRADO"}
+      expected_error = %Error{
+        type: :postal_code_not_found,
+        message: "Postal code not found",
+        reason: "CEP NAO ENCONTRADO"
+      }
 
       assert Subject.find_address("00000-000") == {:error, expected_error}
     end
 
     test "when postal code is empty, returns required error" do
-      expected_error = %Error{type: :some_type, message: "Some message", reason: "postal_code is required"}
+      expected_error = %Error{
+        type: :postal_code_required,
+        message: "Postal code is required",
+        reason: "postal_code is required"
+      }
 
       assert Subject.find_address("") == {:error, expected_error}
     end
 
     test "when postal code has invalid format, returns invalid format error" do
-      expected_error = %Error{type: :some_type, message: "Some message", reason: "postal code in invalid format"}
+      expected_error = %Error{
+        type: :postal_code_invalid,
+        message: "Postal code is invalid",
+        reason: "postal code in invalid format"
+      }
 
       Enum.each(@invalid_postal_codes, fn postal_code ->
         assert Subject.find_address(postal_code) == {:error, expected_error}

--- a/test/correios/cep_test.exs
+++ b/test/correios/cep_test.exs
@@ -44,19 +44,19 @@ defmodule Correios.CEPTest do
     end
 
     test "when postal code is valid and address is not found, returns not found error" do
-      expected_error = %Error{reason: "CEP NAO ENCONTRADO"}
+      expected_error = %Error{type: :some_type, message: "Some message", reason: "CEP NAO ENCONTRADO"}
 
       assert Subject.find_address("00000-000") == {:error, expected_error}
     end
 
     test "when postal code is empty, returns required error" do
-      expected_error = %Error{reason: "postal_code is required"}
+      expected_error = %Error{type: :some_type, message: "Some message", reason: "postal_code is required"}
 
       assert Subject.find_address("") == {:error, expected_error}
     end
 
     test "when postal code has invalid format, returns invalid format error" do
-      expected_error = %Error{reason: "postal code in invalid format"}
+      expected_error = %Error{type: :some_type, message: "Some message", reason: "postal code in invalid format"}
 
       Enum.each(@invalid_postal_codes, fn postal_code ->
         assert Subject.find_address(postal_code) == {:error, expected_error}


### PR DESCRIPTION
The main intent of this PR is to fix #18

- I had to add two more fields to the `Error` struct: `message` and `type` to handle the whole response as expected.
- Another point was to fix the exception raised by cep struct
- Also, create a function called `message` in the Error struct, similar to the `reason` function.

